### PR TITLE
Fixed to run with py34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,19 @@
 
 
 from distutils.core import setup
-import os
 
 from statsd import __version__
 
-def main():
-    cwd = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(cwd, 'README.txt')
-    readme = open(path, 'rb').read()
 
+def fread(filename):
+    with open(filename) as f:
+        return f.read()
+
+
+def main():
     setup(name='statsd-client',
           description='StatsD client for Python',
-          long_description=readme,
+          long_description=fread('README.txt'),
           version=__version__,
           license='Apache 2.0',
           author='Gaelen Hadlett',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This file is part of python-statsd-client released under the Apache
 # License, Version 2.0. See the NOTICE for more information.
 
-from __future__ import absolute_import
+
 from distutils.core import setup
 import os
 

--- a/statsd.py
+++ b/statsd.py
@@ -3,7 +3,7 @@
 # This file is part of python-statsd-client released under the Apache
 # License, Version 2.0. See the NOTICE for more information.
 
-from __future__ import absolute_import
+
 import random
 from socket import socket, AF_INET, SOCK_DGRAM
 import time
@@ -77,7 +77,7 @@ class StatsdClient(object):
                stat = self._prefix + b'.' + stat
 
            self._socket.sendto(stat, (self._host, self._port))
-        except Exception,e:
+        except Exception as e:
             _logger.error("Failed to send statsd packet.", exc_info=True)
 
     def timing(self, bucket, ms, sample_rate=None):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27,py32,py33,py34,pypy
+
+[testenv]
+commands = python statsd_test.py
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py32]
+basepython = python3.2
+
+[testenv:py33]
+basepython = python3.3
+
+[testenv:pypy]
+basepython = pypy


### PR DESCRIPTION
This is blocking https://github.com/mozilla-services/vaurien to be installed in py3.

```
$ pip install vaurien
Collecting vaurien
  Using cached http://pypi...net/packages/vaurien/download/15936/vaurien-1.9.tar.gz
Collecting cornice (from vaurien)
  Using cached http://pypi...net/packages/cornice/download/15944/cornice-1.0.0.tar.gz
Collecting gevent (from vaurien)
  Using cached http://pypi...net/packages/gevent/download/15418/gevent-1.0.2.tar.gz
Collecting statsd-client (from vaurien)
  Using cached statsd-client-1.0.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-8n3b2ym_/statsd-client/setup.py", line 10, in <module>
        from statsd import __version__
      File "/tmp/pip-build-8n3b2ym_/statsd-client/statsd.py", line 80
        except Exception,e:
                        ^
    SyntaxError: invalid syntax
```