### PR TITLE
close _socket in __del__ to avoid ResourceWarning

### DIFF
--- a/statsd.py
+++ b/statsd.py
@@ -45,6 +45,9 @@ class StatsdClient(object):
         if self._prefix and not isinstance(self._prefix, bytes):
             self._prefix = self._prefix.encode('utf8')
 
+    def __del__(self):
+        self._socket.close()
+
     def decr(self, bucket, delta=1, sample_rate=None):
         """Decrements a counter by delta.
         """


### PR DESCRIPTION
I get a ResourceWarning every time a socket is deleted but has not been explicitly closed. This commit fixes it.